### PR TITLE
ci: normalize Figma typography export to old font key structure

### DIFF
--- a/.github/workflows/transform-tokens.yml
+++ b/.github/workflows/transform-tokens.yml
@@ -26,13 +26,18 @@ jobs:
           # it uses the directory named "tokens" to store this json file (change this if you changed it above to use a different folder)
           dir: 'tokens'
 
-      - name: Normalize token structure (re-wrap with variables)
-        # Design Tokens (lukasoppermann/design-tokens) plugin removed the
-        # top-level `variables` wrapper in recent versions and renamed
-        # `font` to `typography`. Downstream consumers depend on the
-        # `variables` wrapper, so we re-wrap it here for compatibility.
-        # `font` <-> `typography` is a content-level change and must be
-        # handled by the consumer, not normalized here.
+      - name: Normalize token structure
+        # Design Tokens (lukasoppermann/design-tokens) plugin changed its
+        # export format in recent versions:
+        #   1. Removed the top-level `variables { core, color, layout, radius }`
+        #      wrapper -- we re-wrap it here.
+        #   2. Renamed `font` to `typography`, restructured by semantic
+        #      category, and introduced weight variants (regular/medium/semibold)
+        #      for body/display/caption -- we map back to old flat keys.
+        # Default-weight mapping is data-verified against the old main:
+        #   body.{size}.regular == old typography-body-saans-{size}
+        #   display.{size}.medium == old typography-display-saans-{size}
+        # Non-default weights are preserved with a -{weight} suffix on the key.
         env:
           TOKENS_DIR: tokens
         run: |
@@ -41,26 +46,93 @@ jobs:
             const path = require("path");
             const dir = process.env.TOKENS_DIR;
             const wrapKeys = ["core", "color", "layout", "radius"];
+
+            // typography category -> old "font" sub-key mapping rules.
+            // familySuffix: appended to category name and embedded in leaf key.
+            // defaultWeight: null = flat leaf (no weight variants); otherwise
+            //   the weight whose token becomes the un-suffixed default.
+            const typoCats = [
+              { name: "title",   familySuffix: "-saans", defaultWeight: null      },
+              { name: "body",    familySuffix: "-saans", defaultWeight: "regular" },
+              { name: "display", familySuffix: "-saans", defaultWeight: "medium"  },
+              { name: "caption", familySuffix: "-saans", defaultWeight: null      },
+              { name: "mono",    familySuffix: "",       defaultWeight: null      },
+            ];
+
+            const leafKey = (cat, suffix, size, weight) => {
+              const base = `typography-${cat}${suffix}-${size}`;
+              return weight ? `${base}-${weight}` : base;
+            };
+
             for (const f of fs.readdirSync(dir)) {
               if (!f.endsWith(".json")) continue;
               const p = path.join(dir, f);
               const j = JSON.parse(fs.readFileSync(p, "utf8"));
-              if (j.variables) continue;
-              if (!wrapKeys.some(k => k in j)) continue;
-              const variables = {};
-              for (const k of wrapKeys) {
-                if (k in j) { variables[k] = j[k]; delete j[k]; }
+              let changed = false;
+
+              // typography -> font
+              if (j.typography && !j.font && typeof j.typography === "object") {
+                const T = j.typography;
+                const font = {};
+
+                for (const { name: cat, familySuffix, defaultWeight } of typoCats) {
+                  const src = T[cat];
+                  if (!src || typeof src !== "object") continue;
+                  const out = {};
+                  for (const [size, val] of Object.entries(src)) {
+                    if (!val || typeof val !== "object") continue;
+                    if ("fontSize" in val) {
+                      out[leafKey(cat, familySuffix, size, null)] = val;
+                    } else {
+                      for (const [weight, tok] of Object.entries(val)) {
+                        const isDefault = weight === defaultWeight;
+                        out[leafKey(cat, familySuffix, size, isDefault ? null : weight)] = tok;
+                      }
+                    }
+                  }
+                  font[`${cat}${familySuffix}`] = out;
+                }
+
+                // x deprecated -> font["title-inter"], font["body-inter"]
+                const dep = T["x deprecated"];
+                if (dep && typeof dep === "object") {
+                  for (const [k, v] of Object.entries(dep)) {
+                    font[k.replace(/\s+/g, "")] = v;
+                  }
+                }
+
+                // font.family / font.weight pass-through
+                if (T.font && typeof T.font === "object") {
+                  if (T.font.family) font.family = T.font.family;
+                  if (T.font.weight) font.weight = T.font.weight;
+                }
+
+                j.font = font;
+                delete j.typography;
+                changed = true;
               }
-              const { effect, font, typography, ...rest } = j;
-              const out = {
-                ...(effect ? { effect } : {}),
-                variables,
-                ...rest,
-                ...(font ? { font } : {}),
-                ...(typography ? { typography } : {}),
-              };
-              fs.writeFileSync(p, JSON.stringify(out, null, 2));
-              console.log("Re-wrapped " + p + " under variables");
+
+              // Re-wrap with `variables`
+              if (!j.variables && wrapKeys.some(k => k in j)) {
+                const variables = {};
+                for (const k of wrapKeys) {
+                  if (k in j) { variables[k] = j[k]; delete j[k]; }
+                }
+                const { effect, font, typography, ...rest } = j;
+                const out = {
+                  ...(effect ? { effect } : {}),
+                  variables,
+                  ...rest,
+                  ...(font ? { font } : {}),
+                  ...(typography ? { typography } : {}),
+                };
+                fs.writeFileSync(p, JSON.stringify(out, null, 2));
+                changed = true;
+              } else if (changed) {
+                fs.writeFileSync(p, JSON.stringify(j, null, 2));
+              }
+
+              if (changed) console.log("Normalized " + p);
             }
           '
 


### PR DESCRIPTION
## Summary

The Design Tokens Figma plugin (lukasoppermann/design-tokens) replaced its `font { ... }` export with a restructured `typography { ... }` block:

- Categories regrouped semantically (`title / body / display / caption / mono`) instead of by font family (`title-saans / body-saans / display-saans / title-inter / body-inter / mono`).
- `body / display / caption` introduced **weight variants** (`regular / medium / semibold`) under each size.
- Inter-family tokens moved to a `typography["x deprecated"]` group.
- New top-level `typography.font.{family, weight}` entries added.

Downstream consumers (e.g. `friendliai/web`) read the old `font["{cat}-saans"]["typography-{cat}-saans-{size}"]` keys. This PR extends the `Normalize token structure` workflow step (introduced in #22) to convert the new typography block back into that old shape so downstream code keeps working.

## Mapping rules

Default-weight selection is **data-verified** against `main`: `body.regular` and `display.medium` produce values identical to the old single-weight tokens.

| Category | Mapping |
| --- | --- |
| `typography.title.{size}` | `font["title-saans"]["typography-title-saans-{size}"]` |
| `typography.body.{size}.regular` | `font["body-saans"]["typography-body-saans-{size}"]` *(default key)* |
| `typography.body.{size}.{medium\|semibold}` | `font["body-saans"]["typography-body-saans-{size}-{weight}"]` |
| `typography.display.{size}.medium` | `font["display-saans"]["typography-display-saans-{size}"]` *(default key)* |
| `typography.display.{size}.semibold` | `font["display-saans"]["typography-display-saans-{size}-semibold"]` |
| `typography.caption.{size}.{weight}` | `font["caption-saans"]["typography-caption-saans-{size}-{weight}"]` *(all new — no old default)* |
| `typography.mono.{size}` | `font.mono["typography-mono-{size}"]` |
| `typography["x deprecated"]["title -inter"]` | `font["title-inter"]` *(whitespace stripped, leaf keys preserved)* |
| `typography["x deprecated"]["body - inter"]` | `font["body-inter"]` |
| `typography.font.{family,weight}` | `font.{family,weight}` *(pass-through)* |

## Safety guarantees

- **Idempotent**: skips if `j.font` already exists or `j.typography` is missing.
- **Data-verified defaults**: sanity-checked locally against `main` — `title-saans.typography-title-saans-2xl`, `body-saans.typography-body-saans-lg`, `display-saans.typography-display-saans-lg`, `mono.typography-mono-lg` all produce byte-identical leaves to the old format.
- **No data loss**: every weight variant from the new structure is preserved (default weight goes to the un-suffixed key, others get a `-{weight}` suffix).
- **Composes with the variables wrap step** (already in `main` from #22): typography conversion runs first, then variables re-wrap, so output ordering matches the old `effect → variables → font` shape.

## Verification

Ran the normalize logic locally against the latest Figma-generated branch (`origin/create-pull-request/patch`). Deep diff of the normalized output vs `main` collapsed from 1131/1211 lines down to only intentional design changes:

```
[CHANGED]  variables.color.fg.neutral.{default,subtle}.value
[ADDED]    variables.color.fg.neutral.subtler
[ADDED]    variables.core.number.96
[ADDED]    effect.shadow-sm-bottom
[REMOVED]  font.body-saans.typography-body-saans-{2xs,xs}    (designer removed sizes)
[ADDED]    font.body-saans.typography-body-saans-{size}-{medium,semibold}    (new weight variants)
[ADDED]    font.display-saans.typography-display-saans-{size}-semibold
[ADDED]    font.caption-saans (entire new category)
[ADDED]    font.{family,weight}
[CHANGED]  font.{title-inter,body-inter}.*.fontFamily / lineHeight
```

## Test plan

- [ ] Merge this PR
- [ ] Trigger a Figma export via the Design Tokens plugin (or re-run `create-pull-request/patch`)
- [ ] Confirm the resulting auto-generated PR shows a small, semantically meaningful diff (no 1000+ line indentation noise)
- [ ] Confirm downstream `friendliai/web` sync still resolves `typography-body-saans-lg` and similar keys