### PR TITLE
fix: write minified JSON in normalize step so prettier formats consistently

### DIFF
--- a/.github/workflows/transform-tokens.yml
+++ b/.github/workflows/transform-tokens.yml
@@ -126,10 +126,13 @@ jobs:
                   ...(font ? { font } : {}),
                   ...(typography ? { typography } : {}),
                 };
-                fs.writeFileSync(p, JSON.stringify(out, null, 2));
+                // Write minified JSON so the subsequent prettier step decides
+                // line breaks natively (default `json` parser keeps short objects
+                // on one line, long ones multi-line — matching mains layout).
+                fs.writeFileSync(p, JSON.stringify(out));
                 changed = true;
               } else if (changed) {
-                fs.writeFileSync(p, JSON.stringify(j, null, 2));
+                fs.writeFileSync(p, JSON.stringify(j));
               }
 
               if (changed) console.log("Normalized " + p);


### PR DESCRIPTION
## Summary

Follow-up to #25. The `Normalize token structure` step was writing pretty-printed JSON via `JSON.stringify(out, null, 2)`, forcing every object onto multiple lines. The subsequent `prettier --write` uses the default `json` parser, which **preserves** existing line breaks instead of reflowing them — so the forced multi-line shape carried through into the committed file.

`main`'s `tokens/design-tokens.json` was originally produced without that intermediate pretty-stringify, so prettier's own 80-column heuristic kicked in: short `{ "type": ..., "value": ... }` objects stayed on a single line, while large typography leaves stayed multi-line. Auto-generated Figma PRs, however, were pushing *everything* to multi-line because of our normalize step, producing huge whitespace-only diffs (e.g. 1131/1211 lines in the recent token PR even when only a few values actually changed).

## Fix

Switch the normalize step's output to `JSON.stringify(out)` (single-line). Prettier then applies its own line-break heuristic and reproduces `main`'s mixed layout naturally.

```diff
-                fs.writeFileSync(p, JSON.stringify(out, null, 2));
+                fs.writeFileSync(p, JSON.stringify(out));
```

(Same change applied to the secondary write path inside the same step.)

## Verification

Ran the patched normalize step locally against `origin/create-pull-request/patch`, then `prettier --write` with the project's `.prettierrc`. Diff vs `main`:

| | line diff |
| --- | --- |
| Before this fix (pretty-stringify + prettier) | **2772** lines |
| After this fix (minified + prettier) | **477** lines |

The remaining 477 lines are real design changes — newly added weight variants (`*-medium`, `*-semibold`), the new `caption-saans` category, `font.{family,weight}`, `effect.shadow-sm-bottom`, `variables.color.fg.neutral.{default,subtle,subtler}` updates, etc. No whitespace-only churn.

Compact-object preservation also confirmed:
- `main`: 380 single-line `{type, value}` objects, 328 multi-line openers
- normalized output: 553 single-line, 348 multi-line (extra count is from new tokens that follow the same compact pattern)

## Test plan

- [ ] Merge this PR
- [ ] Trigger a Figma export via the Design Tokens plugin
- [ ] Confirm the resulting auto-PR diff is small and contains only semantically meaningful changes (no indentation noise)