### PR TITLE
fix: remove apostrophe from comments inside node -e script

### DIFF
--- a/.github/workflows/transform-tokens.yml
+++ b/.github/workflows/transform-tokens.yml
@@ -39,7 +39,7 @@ jobs:
         #      the same number across every variant of a size, so we derive
         #      the correct variable-font axis from the weight key name.
         # Every weight variant carries an explicit -{weight} suffix on the
-        # emitted leaf key, including the category's default weight:
+        # emitted leaf key, including the default weight for the category:
         #   body.{size}.regular   -> typography-body-{size}-regular
         #   display.{size}.medium -> typography-display-{size}-medium
         # This applies whether the variant came in nested under a size
@@ -82,8 +82,8 @@ jobs:
             // single-weight categories ({size: leaf}) and weight-variant
             // categories ({size: {regular|medium|semibold: leaf}}).
             // Every weight variant gets an explicit -{weight} suffix on its
-            // leaf key, including the category's default weight, so the
-            // emitted key always identifies which axis it represents.
+            // leaf key, including the default weight for the category, so
+            // the emitted key always identifies which axis it represents.
             const flattenCategory = (cat, src) => {
               const out = {};
               for (const [sizeKey, val] of Object.entries(src)) {


### PR DESCRIPTION
## Summary

Hotfix for the workflow failure introduced in #45.

The apostrophe in `category's` inside a JS comment closed the surrounding single-quoted `node -e` argument early, so bash interpreted the rest of the JS code as shell commands and failed with `//: Is a directory`.

Reworded the two affected comments to avoid the contraction:
- `category's default weight` → `the default weight for the category`

No behavior change — comments only.

## Test plan

- [ ] Trigger the workflow (Figma dispatch or re-run a recent failed run) and confirm the normalize step completes without `Is a directory` errors.