### PR TITLE
Rename project in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Design Token Transformer
+# FAI Design System
 
 This repo stores Friendli's design tokens (`tokens/*.json`) exported from Figma.
 


### PR DESCRIPTION
Updated project name from 'Design Token Transformer' to 'FAI Design System'.